### PR TITLE
Update CHANGELOG to reflect recent tagged releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 **qStudio is a SQL GUI** that lets you browse tables,
 run SQL scripts, and chart and export the results. 
-qStudio works on every operating system, with every database including mysql, postgresql, mssql, kdb.... 
+qStudio works on every operating system,
+with every database including mysql, postgresql, mssql, kdb.... 
 For more info see:
 [timestored.com/qstudio](https://timestored.com/qstudio)
 
@@ -11,10 +12,28 @@ This file lists the changes that have occurred in the project:
 ## Unreleased 
 
 - Progress toward open-sourcing qStudio
+
+## 3.06 - 2024-06-05 
+- Add Redshift support.
+- DuckDB 1.0.
+- Restore window size on restart.
 - Drag and drop of files into qStudio
 - UI and User Experience improvements
 - Improved logging of environment information
 - Improve connection to SQLite on macOS
+
+## 3.05 - 2023-06-03 
+- copy-paste bugfix.
+
+## 3.04 - 2023-05-30 
+- File->Open handles sqlite/duckdb better. 
+- DolphinDB = v3 driver.
+
+## 3.03 - 2023-05-30
+
+- Improve DolphinDB support.
+- Add auto-complete, documentation etc. 
+- PRQL Mac bugfix.
 
 ## 3.02 - 2024-05-28   
 - Bugfixes and UI improvements. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-**qStudio is a SQL GUI** that lets you browse tables,
-run SQL scripts, and chart and export the results. 
-qStudio works on every operating system,
-with every database including mysql, postgresql, mssql, kdb.... 
+**qStudio is a free SQL GUI** that lets you browse tables,
+run SQL scripts, and chart and export the results.
+qStudio runs on Windows, macOS and Linux, and works with
+every popular database including mysql, postgresql, mssql, kdb…
 For more info see:
 [timestored.com/qstudio](https://timestored.com/qstudio)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 ![Qstudio](qstudio/qstudio.png)
 
-**qStudio is a free SQL GUI**, it allows running SQL scripts, easy browsing of tables, charting and exporting of results. 
-It works on every operating system, with every database including mysql, postgresql, mssql, kdb.... 
+**qStudio is a free SQL GUI** that lets you browse tables,
+run SQL scripts, and chart and export the results.
+qStudio runs on Windows, macOS and Linux, and works with
+every popular database including mysql, postgresql, mssql, kdb…
 For more info see [timestored.com/qstudio](http://timestored.com/qstudio "timestored.com/qstudio")
+
+## Runs on everything
+
+Windows, macOS, Linux
 
 ## Suports Every Database
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,9 +1,14 @@
 # TROUBLESHOOTING
 
-Tips and hints for troubleshooting problems with qStudio
+Tips and hints for troubleshooting problems with qStudio:
 
-- Double-clicking the `.jar` file starts the GUI. But there isn't much diagnostic information available.
-- To get more information, launch qStudio from the command line.
+1. Double-clicking the `.jar` file starts the GUI. It doesn't provide
+much diagnostic information.
+
+2. The **Console** window shows the SQL generated from the PRQL query.
+It also shows any error messages from parsing the query or executing it.
+
+3. To get more information, launch qStudio from the command line.
 The terminal session will display a lot of logging information.
 
    ```

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # TROUBLESHOOTING
 
-Tips and hints for troubleshooting problems with qStudio:
+Tips and hints for installing, using, and troubleshooting problems with qStudio:
 
 1. Double-clicking the `.jar` file starts the GUI. It doesn't provide
 much diagnostic information.
@@ -9,10 +9,17 @@ much diagnostic information.
 It also shows any error messages from parsing the query or executing it.
 
 3. To get more information, launch qStudio from the command line.
-The terminal session will display a lot of logging information.
+The terminal session displays a lot of logging information.
 
    ```
    cd directory-containing-qstudio.jar
    java -jar qstudio.jar
    ```
    
+4. The `prqlc` binary must be installed and available to qStudio.
+  * On macOS, the easiest way to install `prqlc` is with
+  the [Homebrew package manager](https://brew.sh/).
+  It will install the current binary and make it available on the PATH.
+  (Homebrew is a terrific tool because it does not
+  require any superuser permissions,
+  and saves all its files in a few well-known directories.)


### PR DESCRIPTION
This updates the CHANGELOG file to contain the info from recent tags.  I believe all the items listed in the 3.06 section are actually available in that version (I use them...)

In addition, I expanded the info in the TROUBLESHOOTING file