### PR TITLE
Fix connection return and file resource handling

### DIFF
--- a/qstudio/src/main/java/com/timestored/connections/ConnectionManager.java
+++ b/qstudio/src/main/java/com/timestored/connections/ConnectionManager.java
@@ -836,11 +836,10 @@ public class ConnectionManager implements AutoCloseable {
 				throw new IOException("cant find server");
 			}
 			executionSucceeded = execute(sql, conn);
-			returnConn(serverConfig, conn, !executionSucceeded);
 		} catch (IOException e) {
 			LOG.log(Level.WARNING, "error getting connection:\r\n", e);
 		} finally {
-			returnConn(serverConfig, conn, true);
+			returnConn(serverConfig, conn, !executionSucceeded);
 		}
 		
 		return executionSucceeded;

--- a/qstudio/src/main/java/com/timestored/docs/Document.java
+++ b/qstudio/src/main/java/com/timestored/docs/Document.java
@@ -291,22 +291,18 @@ public class Document {
 	}
 	
 	public void saveAs(File file, boolean useWindowsLineEndings) throws IOException {
-		try {
-			BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), Charset.forName("UTF-8")));
+		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), Charset.forName("UTF-8")))) {
 			if(useWindowsLineEndings) {
 				bw.write(content.replace("\n", "\r\n"));
 			} else {
 				bw.write(content);
 			}
-			bw.close();
 			this.file = file;
 			title = file.getName();
 			savedContent = content;
 			for(Listener l : listeners) {
 				l.docSaved();
 			}
-		} catch(IOException ex) {
-			throw new IOException(ex);
 		}
 	}
 
@@ -323,22 +319,17 @@ public class Document {
 	}
 	
 	public void save(boolean useWindowsLineEndings) throws IOException {
-		try {    
-			OutputStreamWriter osw = new OutputStreamWriter(new FileOutputStream(file), "UTF8");
-			BufferedWriter bw = new BufferedWriter(osw);
+		try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF8"))) {
 			if(useWindowsLineEndings) {
 				bw.write(content.replace("\n", "\r\n"));
 			} else {
 				bw.write(content);
 			}
-			bw.close();
 			savedContent = content;
 
 			for(Listener l : listeners) {
 				l.docSaved();
 			}
-		} catch(IOException ex) {
-			throw new IOException(ex);
 		}
 	}
 

--- a/qstudio/src/main/java/com/timestored/misc/IOUtils.java
+++ b/qstudio/src/main/java/com/timestored/misc/IOUtils.java
@@ -37,11 +37,16 @@ public class IOUtils {
 
 	/** Read a file and return it as a string */
 	public static String toString(File file, Charset charset, int bytes) throws IOException {
-		   int bytesToRead = bytes!=-1 ? bytes : (int)file.length(); 
+		   int bytesToRead = bytes!=-1 ? bytes : (int)file.length();
 		   byte[] buffer = new byte[bytesToRead];
-		   BufferedInputStream f = new BufferedInputStream(new FileInputStream(file));
-		   f.read(buffer);
-		   f.close();
+		   try (BufferedInputStream f = new BufferedInputStream(new FileInputStream(file))) {
+			   int totalRead = 0;
+			   while(totalRead < bytesToRead) {
+				   int r = f.read(buffer, totalRead, bytesToRead - totalRead);
+				   if(r == -1) break;
+				   totalRead += r;
+			   }
+		   }
 		   return new String(buffer, charset);
 	}
 
@@ -60,9 +65,13 @@ public class IOUtils {
 	 */
 	public static String toString(@SuppressWarnings("rawtypes") Class c, 
 			String resourceName) throws IOException {
-		// TODO close this stream
-		InputStream is =c.getResourceAsStream(resourceName);
-		return CharStreams.toString(new InputStreamReader(is, Charset.forName("UTF-8")));
+		InputStream is = c.getResourceAsStream(resourceName);
+		if(is == null) {
+			throw new IOException("Resource not found: " + resourceName);
+		}
+		try (InputStreamReader reader = new InputStreamReader(is, Charset.forName("UTF-8"))) {
+			return CharStreams.toString(reader);
+		}
 	}
 	
 	public static void writeStringToFile(String s, File file) throws IOException {

--- a/qstudio/src/main/java/com/timestored/swingxx/TableExporter.java
+++ b/qstudio/src/main/java/com/timestored/swingxx/TableExporter.java
@@ -183,9 +183,9 @@ public class TableExporter {
 	public static void saveTable(JXTable table, StringValue stringValue, boolean selectedAreaOnly, boolean includeHeaders, 
 						String separator, File f) throws java.io.IOException {
     		LOG.info("writing out to: " + f);
-    		FileWriter out = new FileWriter(f);
-    		out.write(TableExporter.getTable(table, stringValue, selectedAreaOnly, includeHeaders, ","));
-    		out.close();
+    		try (FileWriter out = new FileWriter(f)) {
+    			out.write(TableExporter.getTable(table, stringValue, selectedAreaOnly, includeHeaders, ","));
+    		}
 	}
 	
 


### PR DESCRIPTION
## Summary
- avoid returning the same pooled connection twice in single-query execution
- use try-with-resources for document saves and table export writes
- close IOUtils streams reliably and report missing classpath resources

## Testing
- Not run: ant is not installed in this environment