### PR TITLE
Restrict XStream connection deserialization types

### DIFF
--- a/qstudio/src/main/java/com/timestored/connections/ConnectionManager.java
+++ b/qstudio/src/main/java/com/timestored/connections/ConnectionManager.java
@@ -52,7 +52,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.StaxDriver;
-import com.thoughtworks.xstream.security.AnyTypePermission;
+import com.thoughtworks.xstream.security.NoTypePermission;
+import com.thoughtworks.xstream.security.NullPermission;
+import com.thoughtworks.xstream.security.PrimitiveTypePermission;
 import com.timestored.StringUtils;
 import com.timestored.kdb.KdbConnection;
 import com.timestored.plugins.ConnectionDetails;
@@ -115,7 +117,11 @@ public class ConnectionManager implements AutoCloseable {
 	private String prefKey;
 
 	static {
-		xstream.addPermission(AnyTypePermission.ANY);
+		xstream.addPermission(NoTypePermission.NONE);
+		xstream.addPermission(NullPermission.NULL);
+		xstream.addPermission(PrimitiveTypePermission.PRIMITIVES);
+		xstream.allowTypes(new Class<?>[] {
+				ArrayList.class, Integer.class, String.class, JdbcTypes.class, ServerConfigDTO.class });
 		xstream.processAnnotations(ServerConfigDTO.class);
 	}
 	
@@ -1084,4 +1090,3 @@ public class ConnectionManager implements AutoCloseable {
 	}
 
 }
-


### PR DESCRIPTION
## Summary
- remove unrestricted XStream AnyTypePermission for saved connection XML
- deny all types by default and allow only the connection DTO/list/value types required for preferences

## Testing
- Verified the bundled XStream 1.4.13 jar exposes the configured security APIs with javap
- Not run: full Ant build, because ant is not installed in this environment
- Targeted javac compile could not complete outside the project Ant setup because the current JDK/Lombok combination fails annotation processing and disabling processing exposes existing Lombok-generated symbol errors