### PR TITLE
Stop printing AI request payloads

### DIFF
--- a/qstudio/src/main/java/com/timestored/misc/AIFacade.java
+++ b/qstudio/src/main/java/com/timestored/misc/AIFacade.java
@@ -145,7 +145,6 @@ public class AIFacade {
 		urlConnection.setConnectTimeout(15000);
 		urlConnection.setReadTimeout(15000);
 		try (OutputStream os = urlConnection.getOutputStream()) {
-			System.out.println(jsonInputString);
 			byte[] input = jsonInputString.getBytes("utf-8");
 			os.write(input, 0, input.length);
 		}


### PR DESCRIPTION
## Summary
- remove stdout logging of OpenAI request JSON from AIFacade
- avoid exposing user prompts and schema/table context in console output

## Testing
- Not run: ant is not installed in this environment